### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 # Class
 #######################################
 
-Unistep2                   	KEYWORD1
+Unistep2	KEYWORD1
 
 #######################################
 # Methods and Functions
 #######################################
 
-run	                        KEYWORD2
-move                        KEYWORD2
-moveTo                      KEYWORD2
-currentPosition             KEYWORD2
-stepsToGo                   KEYWORD2
-stop                        KEYWORD2
+run	KEYWORD2
+move	KEYWORD2
+moveTo	KEYWORD2
+currentPosition	KEYWORD2
+stepsToGo	KEYWORD2
+stop	KEYWORD2
 
 #######################################
 # Constants


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords